### PR TITLE
Fix --inline arg

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -250,7 +250,7 @@ class downloader:
     def get_inline_images(self, new_post, content_html):
         content_soup = BeautifulSoup(content_html, 'html.parser')
         if self.inline:
-            inline_images = content_soup.find_all("img", {"data-media-id": True})
+            inline_images = content_soup.find_all("img")
             for index, inline_image in enumerate(inline_images):
                 file = {}
                 filename, file_extension = os.path.splitext(inline_image['src'].rsplit('/')[-1])


### PR DESCRIPTION
https://kemono.party/fanbox/user/3188698/post/420615

This link is one of the example

:Before remove arg
![Screen Shot 2022-04-25 at 12 10 31](https://user-images.githubusercontent.com/23118756/165014480-7ce411b9-6abb-4b1d-a1e5-135788860c99.png)
.

in screenshot, BeautifulSoup normally parse html content but after I print inline_images, there is no data in array

:After remove arg
![Screen Shot 2022-04-25 at 12 11 34](https://user-images.githubusercontent.com/23118756/165014565-87049651-c388-488b-afd0-e061fa1582a8.png)
![Screen Shot 2022-04-25 at 12 12 20](https://user-images.githubusercontent.com/23118756/165014651-8056cbfd-9309-42f9-a148-e20f39a6661f.png)


Now normally download inline content from link.
