### PR TITLE
Deploy kemono-dl to Github Docker registry

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,96 @@
+name: Docker
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  push:
+    branches: [ "main" ]
+    # Publish semver tags as releases.
+    tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 #v3.5.0
+        with:
+          cosign-release: 'v2.2.4'
+
+      # Set up BuildKit Docker container builder to be able to build
+      # multi-platform images and export cache
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,8 @@
 FROM python:3
 
 COPY requirements.txt ./
-
-RUN pip install --no-cache-dir --upgrade pip \
-  && pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
-RUN pip install --no-cache-dir .
 
-CMD ["kemono-dl"]
+ENTRYPOINT [ "python", "./kemono-dl/__main__.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ FROM python:3
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY . .
+COPY ./kemono-dl/ .
 
-ENTRYPOINT [ "python", "./kemono-dl/__main__.py" ]
+ENTRYPOINT [ "python", ".__main__.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 FROM python:3
 
-COPY . .
-RUN pip install .
+COPY requirements.txt ./
 
-ENTRYPOINT [ "kemono-dl" ]
+RUN pip install --no-cache-dir --upgrade pip \
+  && pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+RUN pip install --no-cache-dir .
+
+CMD ["kemono-dl"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ FROM python:3
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY ./kemono_dl/ .
+COPY ./kemono_dl/ ./
 
 ENTRYPOINT [ "python", ".__main__.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3
+
+COPY . .
+RUN pip install .
+
+ENTRYPOINT [ "kemono-dl" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ FROM python:3
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY ./kemono-dl/ .
+COPY ./kemono_dl/ .
 
 ENTRYPOINT [ "python", ".__main__.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
 FROM python:3
 
-COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+COPY . ./src
 
-COPY . .
-
-RUN pip install .
+RUN pip install --no-cache-dir -r ./src/requirements.txt
+RUN pip install --no-cache-dir --compile -e ./src && pip cache purge
 
 ENTRYPOINT [ "kemono-dl" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM python:3
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY ./kemono_dl/ ./
+COPY . .
 
-ENTRYPOINT [ "python", ".__main__.py" ]
+RUN pip install .
+
+ENTRYPOINT [ "kemono-dl" ]

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A downloader tool for kemono and coomer websties.
 > Keep in mind that while this template closely mirrors the previous behavior, older versions included logic to truncate file paths and names exceeding 255 characters. This new version does not replicate that trimming exactly, but the template should still work correctly in most cases.
  
 ## How to use
+### Local Installation
 1. **Install Python**  
    Make sure Python 3.11 or later is installed and available in your system PATH.
 
@@ -27,6 +28,24 @@ A downloader tool for kemono and coomer websties.
     ```
 
 > **\*** To update, repeat steps 2 and 3 using the latest release.
+
+### Docker
+You can also use the docker image from github registry which is useful when running the scraper on a NAS or server. An example docker compose file could look like the follwing. This example uses a batch file `URLs.txt` located within the output folder and creates a folder for every creator and service combination. Please mind to change the `PATH_TO_LOCAL_FOLDER` to the folder on your machine.
+```yaml
+services:
+    scraper:
+        image: ghcr.io/AlphaSlayer1964/kemono-dl:main
+        volumes:
+            - "PATH_TO_LOCAL_FOLDER:/out"
+        command:
+            - --output 
+            - "{creator_name}_{service}/{published:%Y%m%d_%H%M%S}_{index}_{filename}"
+            - --batch-file
+            - out/URLs.txt
+            - --path
+            - out
+            - --restrict-name
+```
 
 # Command Line Options
 


### PR DESCRIPTION
As I wanted to run the kemono-dl in docker on my NAS, I quickly added a Dockerfile and a Github Action to this repository, which automatically creates and pushes a new docker image to the registry on every release or merge on the main branch. I also added a bit of documentation to the README about how to use the docker image with a docker-compose configuration.